### PR TITLE
Initialize resource path in all codepaths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Imports:
     XML
 Recommends: XML
 Collate:
+    'init.R'
     'gridster.r'
     'gaugeOutput.R'
     'lineGraphOutput.R'

--- a/R/gaugeOutput.R
+++ b/R/gaugeOutput.R
@@ -37,6 +37,7 @@
 gaugeOutput <- function(outputId, title="Title", min=0, max=1, units="", width="200px", height="200px", value=min) {
   tagList(
     singleton(tags$head(
+      initResourcePaths(),
       tags$script(src = 'shinyDash/justgage/justgage.1.0.1.min.js'),
       tags$script(src = 'shinyDash/justgage/raphael.2.1.0.min.js'),      
       tags$script(src = 'shinyDash/justgage/justgage_binding.js')

--- a/R/graphOutput.R
+++ b/R/graphOutput.R
@@ -27,7 +27,6 @@ graphOutput <- function(outputId, width, height,
                             legend = c("topleft", "topright", "bottomleft", "bottomright"),
                             toolTip = TRUE, 
                             type=c("line", "scatterplot", "area", "bar")) {
-  
   graphType <- match.arg(type)
   
   legendDiv <- ""
@@ -56,6 +55,7 @@ graphOutput <- function(outputId, width, height,
   
   tagList(
     singleton(tags$head(
+      initResourcePaths(),
       tags$script(src = 'shinyDash/rickshaw/d3.v3.min.js'),
       tags$script(src = 'shinyDash/rickshaw/rickshaw.min.js'),
       tags$script(src = 'shinyDash/rickshaw/initRickshaw.js'),

--- a/R/gridster.r
+++ b/R/gridster.r
@@ -28,12 +28,10 @@
 #' @export
 #' @author Winston Chang
 gridster <- function(..., margin.x = 16, margin.y = 16, tile.width = 140, tile.height = 140) {
-  addResourcePath(
-    prefix = 'shinyDash',
-    directoryPath = system.file('shinyDash', package='ShinyDash'))
-
+  init()
   tagList(
     singleton(tags$head(
+      initResourcePaths(),
       tags$script(src = 'shinyDash/gridster/jquery.gridster.min.js'),
       tags$link(rel = 'stylesheet',
                 type = 'text/css',

--- a/R/htmlWidgetOutput.R
+++ b/R/htmlWidgetOutput.R
@@ -8,6 +8,7 @@
 htmlWidgetOutput <- function(outputId, ...) {
   tagList(
     singleton(tags$head(
+      initResourcePaths(),
       tags$script(src = 'shinyDash/base_widget_bindings.js')
     )),
   

--- a/R/init.R
+++ b/R/init.R
@@ -1,0 +1,11 @@
+.global <- new.env()
+
+initResourcePaths <- function() {
+  if (is.null(.global$loaded)) {
+    shiny::addResourcePath(
+      prefix = 'shinyDash',
+      directoryPath = system.file('shinyDash', package='ShinyDash'))
+    .global$loaded <- TRUE
+  }
+  HTML("")
+}

--- a/R/weatherWidgetOutput.R
+++ b/R/weatherWidgetOutput.R
@@ -15,6 +15,7 @@
 #' @export
 weatherWidgetOutput <- function(outputId, width, height) {
   tagList(
+    initResourcePaths(),
     singleton(tags$head(
       tags$script(src = 'shinyDash/base_widget_bindings.js')
     )),


### PR DESCRIPTION
Without this, none of the package JS/CSS assets load unless gridster is used.
