### PR TITLE
Update devtools::install_github call in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A sample application built on the `ShinyDash` package is available [here](https:
 To install, install the `devtools` package if necessary (`install.packages("devtools")`) and run:
 
 ```
-devtools::install_github("ShinyDash", "trestletech")
+devtools::install_github("trestletech/ShinyDash")
 ```
 
 External Javascript libraries used in this app include:


### PR DESCRIPTION
As of at least version 2.2.1 of devtools, calling
`devtools::install_github("ShinyDash", "trestletech")`
will fail and should instead be replaced with
`devtools::install_github("trestletech/ShinyDash")`.